### PR TITLE
[CLI-1142] "Fatal error: The config file "node_modules/grunt-appc-js/.jscsrc" was not found" if grunt-appc-js is called within another grunt plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-appc-js",
   "description": "Linting and style checks for Appcelerator JavaScript",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "homepage": "https://github.com/ingo/grunt-appc-js",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-appc-js",
   "description": "Linting and style checks for Appcelerator JavaScript",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "homepage": "https://github.com/ingo/grunt-appc-js",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-appc-js",
   "description": "Linting and style checks for Appcelerator JavaScript",
-  "version": "1.0.24",
+  "version": "1.0.26",
   "homepage": "https://github.com/ingo/grunt-appc-js",
   "license": "Apache-2.0",
   "author": {

--- a/tasks/appc_js.js
+++ b/tasks/appc_js.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
 			var optionsJscs = {
 				src: source,
 				options: _.omit(that.options({
-					config: 'node_modules/grunt-appc-js/.jscsrc',
+					config: path.join(__dirname, '..', '.jscsrc'),
 					reporter: require('jscs-stylish').path,
 				}), 'globals')
 			};


### PR DESCRIPTION
To validate (after applying fix):

1. Follow steps in ticket
2. Next, in the same appc-registry-server repo, run `npm install grunt-appc-js`
3. In `Gruntfile.js`, replace `appc_js` with `appcJs`; still leaving the options section commented out
4. Add `grunt.loadNpmTasks('grunt-appc-js'); `
5. Run `grunt appcJs`