### PR TITLE
[RDPP-780] Allow lint only of files

### DIFF
--- a/tasks/appc_js.js
+++ b/tasks/appc_js.js
@@ -15,8 +15,7 @@ var _ = require('lodash');
 
 module.exports = function (grunt) {
 
-	grunt.registerMultiTask('appcJs', 'Linting and style checks for Appcelerator JavaScript', function () {
-
+	grunt.registerMultiTask('appcJs', 'Linting and style checks for Appcelerator JavaScript', function (lintOnly) {
 		var that = this;
 		var source = this.data;
 		if (this.data.src) {
@@ -25,10 +24,16 @@ module.exports = function (grunt) {
 
 		initializeJscsPlugin();
 		initializeJshintPlugin();
-		initializeContinuePlugin();
-		initializeRetirePlugin();
+		if(lintOnly) {
+			grunt.task.run('jshint:src', 'jscs:src');
+		} else {
+			initializeContinuePlugin();
+			initializeRetirePlugin();
+			grunt.task.run('jshint:src', 'jscs:src', 'continue:on', 'retire', 'continue:off');
 
-		grunt.task.run('jshint:src', 'jscs:src', 'continue:on', 'retire', 'continue:off');
+		}
+
+
 
 		/**
 		 * Initializes the jscs plugin


### PR DESCRIPTION
Example of usage would be grunt.registerTask('lint', 'appcJs:src:lintOnly');

I took the simplest path to ensure that it doesn't break existing usage of registering just appcJs and avoid having multiple configs
