### PR TITLE
Add nsp check

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
   },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-cli": "^1.2.0",
     "grunt-bump": "^0.8.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-nsp": "^2.3.1",
     "load-grunt-tasks": "^3.3.0",
     "time-grunt": "^1.2.2"
   },

--- a/tasks/appc_js.js
+++ b/tasks/appc_js.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var extendGruntPlugin = require('extend-grunt-plugin');
+var fs = require('fs');
 var packpath = require('packpath');
 var path = require('path');
 var _ = require('lodash');
@@ -24,16 +25,14 @@ module.exports = function (grunt) {
 
 		initializeJscsPlugin();
 		initializeJshintPlugin();
-		if(lintOnly) {
+		if (lintOnly) {
 			grunt.task.run('jshint:src', 'jscs:src');
 		} else {
 			initializeContinuePlugin();
 			initializeRetirePlugin();
-			grunt.task.run('jshint:src', 'jscs:src', 'continue:on', 'retire', 'continue:off');
-
+			initializeNSPPlugin();
+			grunt.task.run('jshint:src', 'jscs:src', 'continue:on', 'retire', 'nsp', 'continue:off');
 		}
-
-
 
 		/**
 		 * Initializes the jscs plugin
@@ -127,6 +126,26 @@ module.exports = function (grunt) {
 			var retire = require('grunt-retire/tasks/retire');
 			retire(grunt);
 			grunt.config.set('retire', optionsRetire);
+		}
+
+		/**
+		 * Initializes the NSP plugin
+		 * @return {void}
+		 */
+		function initializeNSPPlugin() {
+			var pkg = path.join(process.cwd(), 'package');
+			var nsp = require('grunt-nsp/tasks/nsp');
+			if (fs.existsSync(pkg)) {
+				extendGruntPlugin(grunt, nsp, {
+					'nsp.package' : pkg,
+					'nsp.output' : 'summary'
+				});
+			} else {
+				grunt.log.error('Could not find package.json at ' + pkg + ' skipping nsp check');
+				extendGruntPlugin(grunt, nsp, {
+					'nsp.output' : 'none'
+				});
+			}
 		}
 
 		/**


### PR DESCRIPTION
- Adds nsp to run as part of the default task
  - Reads in the package.json using process.cwd() if not found logs that it can not find it but does not fail the grunt task
  - Uses the summary output rather than default as it takes up less space
